### PR TITLE
Qiita 投稿機能の細かい修正

### DIFF
--- a/lib/qiita_exporter.rb
+++ b/lib/qiita_exporter.rb
@@ -49,7 +49,7 @@ class QiitaExporter
   def progress(team)
     goal = team.goals.last
     sum = goal.progresses.sum(:amount)
-    "今月の達成度 : #{sum}/#{goal.goal} #{entity(team)} (#{((sum.to_f/goal.goal.to_f) * 100).to_i}%)"
+    "今月の達成度 : #{sum}/#{goal.goal} #{entity(team)} (#{((sum.to_f/goal.goal.to_f) * 100).to_i.to_s(:delimited)}%)"
   end
 
   def topics(team)

--- a/lib/qiita_exporter.rb
+++ b/lib/qiita_exporter.rb
@@ -49,7 +49,7 @@ class QiitaExporter
   def progress(team)
     goal = team.goals.last
     sum = goal.progresses.sum(:amount)
-    "今月の達成度 : #{sum}/#{goal.goal} #{entity(team)} (#{((sum.to_f/goal.goal.to_f) * 100).to_i.to_s(:delimited)}%)"
+    "今月の達成度 : #{sum.to_i.to_s(:delimited)}/#{goal.goal.to_i.to_s(:delimited)} #{entity(team)} (#{((sum.to_f/goal.goal.to_f) * 100)}%)"
   end
 
   def topics(team)

--- a/lib/qiita_exporter.rb
+++ b/lib/qiita_exporter.rb
@@ -29,13 +29,13 @@ class QiitaExporter
 
   def tags
     [
-      { name: '全体朝会', versions: [] }
+      { name: '全体朝礼', versions: [] }
     ]
   end
 
   def title
     now = Time.current.in_time_zone('Asia/Tokyo')
-    %(#{now.year}/#{now.month}/#{now.day} 月曜全体朝会まとめ)
+    %(#{now.year}/#{now.month}/#{now.day} 月曜全体朝礼まとめ)
   end
 
   def body

--- a/lib/qiita_exporter.rb
+++ b/lib/qiita_exporter.rb
@@ -4,14 +4,17 @@ require 'erb'
 
 class QiitaExporter
   def self.exec
-    @@instance ||= self.new
-    @@instance.client.create_item(@@instance.params)
+    new.create_item
+  end
+
+  def create_item
+    client.create_item(params)
   end
 
   def client
     @client ||= Qiita::Client.new(
       access_token: ENV['QIITA_ACCESS_TOKEN'],
-      team: ENV['QIITA_TEAM_NAME']
+      team: ENV['QIITA_TEAM_NAME'],
     )
   end
 
@@ -50,7 +53,6 @@ class QiitaExporter
   end
 
   def entity(team)
-    return '(件)' if team.orders?
-    return '(円)' if team.sales?
+    team.orders? ? '(件)' : '(円)'
   end
 end

--- a/lib/qiita_exporter.rb
+++ b/lib/qiita_exporter.rb
@@ -42,6 +42,10 @@ class QiitaExporter
     ERB.new(File.read('./lib/template.md'), nil, '-').result(binding)
   end
 
+  def teams
+    Team.order(:order)
+  end
+
   def progress(team)
     goal = team.goals.last
     sum = goal.progresses.sum(:amount)

--- a/lib/template.md
+++ b/lib/template.md
@@ -10,8 +10,7 @@
 ### 先週のトピック
 
     <%- topics.each do |topic| -%>
-- <%= topic.content %>
-
+<%= '- ' + topic.content + "\n\n" if topic.content.present? -%>
     <%- end -%>
   <%- end -%>
 <%- end -%>

--- a/lib/template.md
+++ b/lib/template.md
@@ -1,4 +1,4 @@
-<%- Team.all.each do |team| -%>
+<%- teams.each do |team| -%>
 ## <%= team.name %>
 
 ### <%= progress(team) %>


### PR DESCRIPTION
### PR の目的

今週初めて Qiita 投稿機能が動いた際に気になった点をいくつか修正しました :eyes:
対応箇所は以下になります。

- コードのリファクタリング ( 041f146 )
- 記事のチーム順と発表のチーム順を揃えたい ( 0b853a1 )
- 全体「朝会」ではなく全体「朝礼」に変更 ( a950b6a )
- トピックが存在しない場合も箇条書きの空項目が生成されてしまう ( ba391c1 )

### 動作確認

- [ ] Qiita に投稿可能なこと
- [ ] タグが `全体朝礼` , 記事タイトルが `月曜全体朝礼まとめ` であること
- [ ] 記載される順が発表順と等しくなること
- [ ] `content` が空のトピックが出力されないこと