### PR TITLE
不適な文言を調整

### DIFF
--- a/app/views/goals/index.html.slim
+++ b/app/views/goals/index.html.slim
@@ -43,7 +43,7 @@
               = link_to new_team_goal_progress_path(@team, goal) do
                 button_tag.btn.btn-primary
                   span.glyphicon.glyphicon-plus.btn-icon
-                  | 先週の進捗追加
+                  | 進捗追加
 
             td
               = link_to edit_team_goal_path(@team, goal), action: :edit do


### PR DESCRIPTION
やったこと
--

+ 目標一覧から、進捗を作成するときに、先月の進捗追加というボタンは不適なので、変更した


### before
![morningmeetingchart](https://cloud.githubusercontent.com/assets/3479317/18160793/f8dbfee2-7069-11e6-9dd3-b072c9cff4ec.png)

### after
![morningmeetingchart](https://cloud.githubusercontent.com/assets/3479317/18160775/dcd28fcc-7069-11e6-975c-02ddabd84e85.png)


やらないこと
--
+ 新規追加時の日付の調整
   + 過去の月を扱う時は、その月の１日が開始日になってるほうが良さそうな気がしている
