### PR TITLE
Topicは1つのみで、マークダウンを使うようにする

### DIFF
--- a/app/assets/stylesheets/global.scss
+++ b/app/assets/stylesheets/global.scss
@@ -42,6 +42,11 @@ div.container-preview {
   margin-right: 5%;
 }
 
+div.container-topics {
+  font-size: 1.5em;
+  margin-left: 1em;
+}
+
 .footer {
   position: absolute;
   bottom: 0;
@@ -54,11 +59,6 @@ div.container-preview {
   font-size: 20px;
   font-weight: bolder;
   margin: 20px 0;
-}
-
-li.topics {
-  font-size: 1.7em;
-  margin-left: 1em;
 }
 
 td {

--- a/app/assets/stylesheets/global.scss
+++ b/app/assets/stylesheets/global.scss
@@ -43,7 +43,7 @@ div.container-preview {
 }
 
 div.container-topics {
-  font-size: 2em;
+  font-size: 1.8em;
   margin-left: 1em;
   line-height: 2em;
 }

--- a/app/assets/stylesheets/global.scss
+++ b/app/assets/stylesheets/global.scss
@@ -43,7 +43,7 @@ div.container-preview {
 }
 
 div.container-topics {
-  font-size: 1.5em;
+  font-size: 1.7em;
   margin-left: 1em;
 }
 

--- a/app/assets/stylesheets/global.scss
+++ b/app/assets/stylesheets/global.scss
@@ -43,8 +43,9 @@ div.container-preview {
 }
 
 div.container-topics {
-  font-size: 1.7em;
+  font-size: 2em;
   margin-left: 1em;
+  line-height: 2em;
 }
 
 .footer {

--- a/app/controllers/progresses_controller.rb
+++ b/app/controllers/progresses_controller.rb
@@ -10,6 +10,10 @@ class ProgressesController < ApplicationController
   def new
     @start_date = last_monday
     @end_date = last_monday + 4
+    @topic_template = %|## Topics
+- {ここにトピックを記入}
+- {ここにトピックを記入}
+- {ここにトピックを記入}|
   end
 
   def edit

--- a/app/controllers/progresses_controller.rb
+++ b/app/controllers/progresses_controller.rb
@@ -18,14 +18,7 @@ class ProgressesController < ApplicationController
   def update
     ActiveRecord::Base.transaction do
       @progress.update(progress_params)
-      topic_params.each_with_index do |param, index|
-        topic = @progress.topics[index]
-        if topic
-          topic.update!(content: param.last)
-        else
-          @progress.topics.create(content: param.last) if param.last
-        end
-      end
+      @progress.topic.update(topic_params)
     end
     redirect_to team_path(params[:team_id]), notice: '更新されました'
   rescue

--- a/app/controllers/progresses_controller.rb
+++ b/app/controllers/progresses_controller.rb
@@ -35,9 +35,7 @@ class ProgressesController < ApplicationController
   def create
     ActiveRecord::Base.transaction do
       @progress = Progress.create!(progress_params)
-      topic_params.each do |_key, val|
-        @progress.topics.create!(content: val)
-      end
+      Topic.create!(progress_id: @progress.id, content: topic_params[:content])
     end
     redirect_to team_path(params[:team_id]), notice: '作成されました'
   rescue
@@ -76,7 +74,7 @@ class ProgressesController < ApplicationController
   end
 
   def topic_params
-    params.require(:topic).require(:content).permit('0', '1', '2')
+    params.require(:topic).permit(:content)
   end
 
   def last_monday

--- a/app/controllers/progresses_controller.rb
+++ b/app/controllers/progresses_controller.rb
@@ -11,9 +11,14 @@ class ProgressesController < ApplicationController
     @start_date = last_monday
     @end_date = last_monday + 4
     @topic_template = %|## Topics
-- {ここにトピックを記入}
-- {ここにトピックを記入}
-- {ここにトピックを記入}|
+### {ここにトピックを記入}
++ {ここに内容を記入}
+
+### {ここにトピックを記入}
++ {ここに内容を記入}
+
+### {ここにトピックを記入}
++ {ここに内容を記入}|
   end
 
   def edit

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -11,7 +11,7 @@ class TeamsController < ApplicationController
   # GET /teams/1.json
   def show
     if can_create_graph?
-      @goal = @goals.order(:date).last
+      @goal = @goals.last
       @graph = Graph.create(@goal)
       @sum = @goal.progresses.sum(:amount)
     else

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -12,6 +12,7 @@ class TeamsController < ApplicationController
   def show
     if can_create_graph?
       @goal = @goals.last
+      @topic = @goal.topics.last
       @graph = Graph.create(@goal)
       @sum = @goal.progresses.sum(:amount)
     else

--- a/app/models/goal.rb
+++ b/app/models/goal.rb
@@ -12,6 +12,7 @@
 
 class Goal < ApplicationRecord
   has_many :progresses, dependent: :destroy
+  has_many :topics, through: :progresses
   belongs_to :team
 
   validates :date, presence: true

--- a/app/models/progress.rb
+++ b/app/models/progress.rb
@@ -12,7 +12,7 @@
 #
 
 class Progress < ApplicationRecord
-  has_many :topics, dependent: :destroy
+  has_one :topic, dependent: :destroy
   belongs_to :goal
 
   validates :start_date, presence: true

--- a/app/views/progresses/edit.html.slim
+++ b/app/views/progresses/edit.html.slim
@@ -28,7 +28,7 @@
       .col-xs-5
         .form-group
           = label_tag 'トピック'
-          = text_area_tag 'topic[content]', @progress.topic.content, class: 'form-control'
+          = text_area_tag 'topic[content]', @progress.topic.content, class: 'form-control', size: '20x20'
 
     .row
       .col-xs-5

--- a/app/views/progresses/edit.html.slim
+++ b/app/views/progresses/edit.html.slim
@@ -27,7 +27,7 @@
     .row
       .col-xs-5
         .form-group
-          = label_tag 'トピック'
+          = label_tag 'トピック(Markdown形式)'
           = text_area_tag 'topic[content]', @progress.topic.content, class: 'form-control', size: '20x10'
 
     .row

--- a/app/views/progresses/edit.html.slim
+++ b/app/views/progresses/edit.html.slim
@@ -28,7 +28,7 @@
       .col-xs-5
         .form-group
           = label_tag 'トピック'
-          = text_area_tag 'topic[content]', @progress.topic.content, class: 'form-control', size: '20x20'
+          = text_area_tag 'topic[content]', @progress.topic.content, class: 'form-control', size: '20x10'
 
     .row
       .col-xs-5

--- a/app/views/progresses/edit.html.slim
+++ b/app/views/progresses/edit.html.slim
@@ -30,22 +30,8 @@
       .col-xs-5
         .form-group
           .form-group
-            = label_tag 'トピック1'
-            = text_field_tag 'topic[content][0]', @progress.topics[0]&.content, class: 'form-control'
-
-    .row
-      .col-xs-5
-        .form-group
-          .form-group
-            = label_tag 'トピック2'
-            = text_field_tag 'topic[content][1]', @progress.topics[1]&.content, class: 'form-control'
-
-    .row
-      .col-xs-5
-        .form-group
-          .form-group
-            = label_tag 'トピック3'
-            = text_field_tag 'topic[content][2]', @progress.topics[2]&.content, class: 'form-control'
+            = label_tag 'トピック'
+            = text_field_tag 'topic[content]', @progress.topic.content, class: 'form-control'
 
     .row
       .col-xs-5

--- a/app/views/progresses/edit.html.slim
+++ b/app/views/progresses/edit.html.slim
@@ -1,6 +1,5 @@
 .container
-  h1
-    | チーム情報編集
+  h1 進捗状況編集
 
 .container
   hr
@@ -22,16 +21,14 @@
     .row
       .col-xs-5
         .form-group
-          .form-group
-            = label_tag '成果'
-            = text_field_tag 'progress[amount]', @progress.amount, class: 'form-control'
+          = label_tag '成果'
+          = text_field_tag 'progress[amount]', @progress.amount, class: 'form-control'
 
     .row
       .col-xs-5
         .form-group
-          .form-group
-            = label_tag 'トピック'
-            = text_field_tag 'topic[content]', @progress.topic.content, class: 'form-control'
+          = label_tag 'トピック'
+          = text_area_tag 'topic[content]', @progress.topic.content, class: 'form-control'
 
     .row
       .col-xs-5

--- a/app/views/progresses/new.html.slim
+++ b/app/views/progresses/new.html.slim
@@ -28,7 +28,7 @@
       .col-xs-5
         .form-group
           = label_tag 'トピック'
-          = text_area_tag 'topic[content]', nil, class: 'form-control'
+          = text_area_tag 'topic[content]', nil, class: 'form-control', size: '20x20'
 
     .row
       .col-xs-5

--- a/app/views/progresses/new.html.slim
+++ b/app/views/progresses/new.html.slim
@@ -27,8 +27,8 @@
     .row
       .col-xs-5
         .form-group
-          = label_tag 'トピック'
-          = text_area_tag 'topic[content]', nil, class: 'form-control', size: '20x10'
+          = label_tag 'トピック(Markdown形式)'
+          = text_area_tag 'topic[content]', @topic_template, class: 'form-control', size: '20x10'
 
     .row
       .col-xs-5

--- a/app/views/progresses/new.html.slim
+++ b/app/views/progresses/new.html.slim
@@ -1,6 +1,9 @@
 .container
   h1 進捗どうですか？
 
+.container
+  hr
+
 .container.container-form
   = form_tag("/teams/#{params[:team_id]}/goals/#{params[:goal_id]}/progresses", method: 'post') do
     .row
@@ -25,7 +28,7 @@
       .col-xs-5
         .form-group
           = label_tag 'トピック'
-          = text_field_tag 'topic[content]', nil, class: 'form-control'
+          = text_area_tag 'topic[content]', nil, class: 'form-control'
 
     .row
       .col-xs-5

--- a/app/views/progresses/new.html.slim
+++ b/app/views/progresses/new.html.slim
@@ -24,20 +24,8 @@
     .row
       .col-xs-5
         .form-group
-          = label_tag 'トピック1'
-          = text_field_tag 'topic[content][0]', nil, class: 'form-control'
-
-    .row
-      .col-xs-5
-        .form-group
-          = label_tag 'トピック2'
-          = text_field_tag 'topic[content][1]', nil, class: 'form-control'
-
-    .row
-      .col-xs-5
-        .form-group
-          = label_tag 'トピック3'
-          = text_field_tag 'topic[content][2]', nil, class: 'form-control'
+          = label_tag 'トピック'
+          = text_field_tag 'topic[content]', nil, class: 'form-control'
 
     .row
       .col-xs-5

--- a/app/views/progresses/new.html.slim
+++ b/app/views/progresses/new.html.slim
@@ -28,7 +28,7 @@
       .col-xs-5
         .form-group
           = label_tag 'トピック'
-          = text_area_tag 'topic[content]', nil, class: 'form-control', size: '20x20'
+          = text_area_tag 'topic[content]', nil, class: 'form-control', size: '20x10'
 
     .row
       .col-xs-5

--- a/app/views/teams/show.html.slim
+++ b/app/views/teams/show.html.slim
@@ -16,10 +16,9 @@
       h2
         span.glyphicon.glyphicon-ok.title-icon aria-hidden="true"
         | Topics
-      - if @goal.present?
-        - if @goal.progresses.latest.topic.present?
-          .container-topics
-            = markdown(@goal.progresses.latest.topic.content)
+      - if @topic.present?
+        .container-topics
+          = markdown(@topic.content)
 
 .container-preview
   hr

--- a/app/views/teams/show.html.slim
+++ b/app/views/teams/show.html.slim
@@ -13,9 +13,6 @@
       - if @team.goals.present?
         = high_chart("chart-#{@team.id}", @graph)
     .col-xs-6
-      h2
-        span.glyphicon.glyphicon-ok.title-icon aria-hidden="true"
-        | Topics
       - if @topic.present?
         .container-topics
           = markdown(@topic.content)

--- a/app/views/teams/show.html.slim
+++ b/app/views/teams/show.html.slim
@@ -18,10 +18,9 @@
         | Topics
       - if @goals.present?
         ul.list-group
-        - @goals.last.progresses.latest.topics.each do |topic|
-          - if topic.content.present?
+          - if @goals.last.progresses.latest.topic.content.present?
             li.topics
-              = auto_link(topic.content)
+              = auto_link(@goals.last.progresses.latest.topic.content)
 
 .container-preview
   hr

--- a/app/views/teams/show.html.slim
+++ b/app/views/teams/show.html.slim
@@ -16,10 +16,10 @@
       h2
         span.glyphicon.glyphicon-ok.title-icon aria-hidden="true"
         | Topics
-      - if @goals.present?
-        - if @goals.last.progresses.latest.topic.content.present?
+      - if @goal.present?
+        - if @goal.progresses.latest.topic.present?
           .container-topics
-            = markdown(@goals.last.progresses.latest.topic.content)
+            = markdown(@goal.progresses.latest.topic.content)
 
 .container-preview
   hr

--- a/app/views/teams/show.html.slim
+++ b/app/views/teams/show.html.slim
@@ -17,9 +17,8 @@
         span.glyphicon.glyphicon-ok.title-icon aria-hidden="true"
         | Topics
       - if @goals.present?
-        ul.list-group
-          - if @goals.last.progresses.latest.topic.content.present?
-            = markdown(@goals.last.progresses.latest.topic.content)
+        - if @goals.last.progresses.latest.topic.content.present?
+          = markdown(@goals.last.progresses.latest.topic.content)
 
 .container-preview
   hr

--- a/app/views/teams/show.html.slim
+++ b/app/views/teams/show.html.slim
@@ -19,8 +19,7 @@
       - if @goals.present?
         ul.list-group
           - if @goals.last.progresses.latest.topic.content.present?
-            li.topics
-              = auto_link(@goals.last.progresses.latest.topic.content)
+            = markdown(@goals.last.progresses.latest.topic.content)
 
 .container-preview
   hr

--- a/app/views/teams/show.html.slim
+++ b/app/views/teams/show.html.slim
@@ -18,7 +18,8 @@
         | Topics
       - if @goals.present?
         - if @goals.last.progresses.latest.topic.content.present?
-          = markdown(@goals.last.progresses.latest.topic.content)
+          .container-topics
+            = markdown(@goals.last.progresses.latest.topic.content)
 
 .container-preview
   hr


### PR DESCRIPTION
### やりたかったこと

Topicを3つバラバラに登録する方式だと順番が狂ったり、
そもそも柔軟な表現ができないという問題がある。

そのため、全体共有事項と同じくMarkdownで記述してもらうようにし、
順番が狂うといった問題点を解消する。
（ついでにDBのレコード数も削減できる）


### やったこと

- トピック入力欄を1つにし、作成するトピック数も1つにした
- Progressのnew, edit フォームの修正
  - css調整含む
- https://github.com/feedforce/morning-meeting-chart/pull/91#issuecomment-247203372 のような関連付けの導入

### やってないこと

- Qiita 投稿部分はノータッチ

### 確認

- [ ] プレビュー画面でTopicがMarkdownでパースされて登録されることを確認
- [ ] トピック入力欄が1つで、text_area になっていることを確認
- [ ] LGTM