### PR TITLE
ラベルの作成時もstart_date でソートする

### DIFF
--- a/lib/graph.rb
+++ b/lib/graph.rb
@@ -67,7 +67,7 @@ module Graph
     end
 
     def single_categories
-      @goals.progresses.map do |progress|
+      @goals.progresses.order(:start_date).map do |progress|
         "#{progress.start_date.day}〜#{(progress.end_date).day}日"
       end
     end


### PR DESCRIPTION
x軸のラベル付けがずれている件。

ラベル作成時にソートするのが漏れていたので修正した。
以下のようなデータでも正しくグラフが作成できることを確認。

```rb
[1] pry(main)> Goal.last
  Goal Load (0.2ms)  SELECT  "goals".* FROM "goals" ORDER BY "goals"."id" DESC LIMIT ?  [["LIMIT", 1]]
+----+------------+------+---------+-------------------------+-------------------------+
| id | date       | goal | team_id | created_at              | updated_at              |
+----+------------+------+---------+-------------------------+-------------------------+
| 2  | 2016-07-01 | 18   | 2       | 2016-09-30 05:14:39 UTC | 2016-09-30 05:14:39 UTC |
+----+------------+------+---------+-------------------------+-------------------------+
1 row in set
[2] pry(main)> Goal.last.progresses
  Goal Load (0.1ms)  SELECT  "goals".* FROM "goals" ORDER BY "goals"."id" DESC LIMIT ?  [["LIMIT", 1]]
  Progress Load (0.4ms)  SELECT "progresses".* FROM "progresses" WHERE "progresses"."goal_id" = ?  [["goal_id", 2]]
+----+------------+--------+-------------------------+-------------------------+------------+---------+
| id | start_date | amount | created_at              | updated_at              | end_date   | goal_id |
+----+------------+--------+-------------------------+-------------------------+------------+---------+
| 2  | 2016-07-04 | 7      | 2016-09-30 05:14:39 UTC | 2016-09-30 05:14:39 UTC | 2016-07-08 | 2       |
| 4  | 2016-07-11 | 6      | 2016-09-30 05:14:39 UTC | 2016-09-30 05:14:39 UTC | 2016-07-15 | 2       |
| 6  | 2016-07-18 | 8      | 2016-09-30 05:14:39 UTC | 2016-09-30 05:14:39 UTC | 2016-07-22 | 2       |
| 9  | 2016-07-01 | 7      | 2016-09-30 05:16:42 UTC | 2016-09-30 05:18:23 UTC | 2016-10-14 | 2       |
+----+------------+--------+-------------------------+-------------------------+------------+---------+
```