### PR TITLE
先週の月曜を求めるメソッドが間違えていた

### DIFF
--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -42,6 +42,6 @@ class Team < ApplicationRecord
 
   def last_monday
     this_day = Date.today
-    (this_day - (this_day.wday - 1)) - 7
+    this_day - (this_day.wday - 1)
   end
 end


### PR DESCRIPTION
本番環境で見ていて気づいた。
１週間余計に引いていた

```rb
irb(main):007:0> this_day = Date.today
=> Fri, 07 Oct 2016
irb(main):008:0> (this_day - (this_day.wday - 1)) - 7
=> Mon, 26 Sep 2016
irb(main):009:0> this_day.wday - 1
=> 4
irb(main):010:0> this_day - (this_day.wday - 1)
=> Mon, 03 Oct 2016
irb(main):011:0> this_day - (this_day.wday - 1) - 7
=> Mon, 26 Sep 2016
irb(main):012:0> this_day - (this_day.wday - 1)
=> Mon, 03 Oct 2016
irb(main):013:0> this_day = Date.new(2016,11,3)
=> Thu, 03 Nov 2016
irb(main):014:0> this_day - (this_day.wday - 1)
=> Mon, 31 Oct 2016
```