### PR TITLE
トピック周りの見た目を調節

### DIFF
--- a/app/assets/stylesheets/global.scss
+++ b/app/assets/stylesheets/global.scss
@@ -43,7 +43,7 @@ div.container-preview {
 }
 
 div.container-topics {
-  font-size: 1.8em;
+  font-size: 1.4em;
   margin-left: 1em;
   line-height: 2em;
 }

--- a/app/controllers/progresses_controller.rb
+++ b/app/controllers/progresses_controller.rb
@@ -10,14 +10,13 @@ class ProgressesController < ApplicationController
   def new
     @start_date = last_monday
     @end_date = last_monday + 4
-    @topic_template = %|## Topics
-### {ここにトピックを記入}
+    @topic_template = %|## {ここにトピックを記入}
 + {ここに内容を記入}
 
-### {ここにトピックを記入}
+## {ここにトピックを記入}
 + {ここに内容を記入}
 
-### {ここにトピックを記入}
+## {ここにトピックを記入}
 + {ここに内容を記入}|
   end
 

--- a/app/views/progresses/edit.html.slim
+++ b/app/views/progresses/edit.html.slim
@@ -25,10 +25,10 @@
           = text_field_tag 'progress[amount]', @progress.amount, class: 'form-control'
 
     .row
-      .col-xs-5
+      .col-xs-8
         .form-group
           = label_tag 'トピック(Markdown形式)'
-          = text_area_tag 'topic[content]', @progress.topic.content, class: 'form-control', size: '20x10'
+          = text_area_tag 'topic[content]', @progress.topic.content, class: 'form-control', size: '20x20'
 
     .row
       .col-xs-5

--- a/app/views/progresses/new.html.slim
+++ b/app/views/progresses/new.html.slim
@@ -25,10 +25,10 @@
           = text_field_tag 'progress[amount]', nil, class: 'form-control'
 
     .row
-      .col-xs-5
+      .col-xs-8
         .form-group
           = label_tag 'トピック(Markdown形式)'
-          = text_area_tag 'topic[content]', @topic_template, class: 'form-control', size: '20x10'
+          = text_area_tag 'topic[content]', @topic_template, class: 'form-control', size: '20x20'
 
     .row
       .col-xs-5


### PR DESCRIPTION
### やりたかったこと

#95 の対応。


### やったこと

- `progress#new, edit` のトピック入力フォームサイズの拡大
- プレビュー画面でのトピック表示欄のフォントサイズ調整


### 確認

- [ ] LGTM