### PR TITLE
team/show を表示する際、チーム名から表示させるようにした PR の作り直し

### DIFF
--- a/app/views/teams/_next_prev_button.html.slim
+++ b/app/views/teams/_next_prev_button.html.slim
@@ -1,0 +1,24 @@
+.container-preview
+  ul.pager
+    - if Team.has_prev_team?(@team.order)
+      li.previous
+        - prev_team = Team.prev_team(@team.order)
+        = link_to(team_path(prev_team.id)) do
+          span aria-hidden="true"
+            | &larr;&nbsp;
+          = prev_team.name
+
+    - if Team.has_next_team?(@team.order)
+      li.next
+        - next_team = Team.next_team(@team.order)
+        = link_to(team_path(next_team.id)) do
+          = next_team.name
+          span aria-hidden="true"
+            | &nbsp;&rarr;
+    - elsif SharedInfo.exists?(['? < announce_date AND announce_date <= ?', Date.today - 7, Date.today])
+      li.next
+        - shared_info = SharedInfo.this_period.order(:id).first
+        = link_to(shared_info_path(shared_info.id)) do
+          = shared_info.title
+          span aria-hidden="true"
+            | &nbsp;&rarr;

--- a/app/views/teams/_next_prev_button.html.slim
+++ b/app/views/teams/_next_prev_button.html.slim
@@ -1,24 +1,23 @@
-.container-preview
-  ul.pager
-    - if Team.has_prev_team?(@team.order)
-      li.previous
-        - prev_team = Team.prev_team(@team.order)
-        = link_to(team_path(prev_team.id)) do
-          span aria-hidden="true"
-            | &larr;&nbsp;
-          = prev_team.name
+ul.pager
+  - if Team.has_prev_team?(@team.order)
+    li.previous
+      - prev_team = Team.prev_team(@team.order)
+      = link_to(team_path(prev_team.id)) do
+        span aria-hidden="true"
+          | &larr;&nbsp;
+        = prev_team.name
 
-    - if Team.has_next_team?(@team.order)
-      li.next
-        - next_team = Team.next_team(@team.order)
-        = link_to(team_path(next_team.id)) do
-          = next_team.name
-          span aria-hidden="true"
-            | &nbsp;&rarr;
-    - elsif SharedInfo.exists?(['? < announce_date AND announce_date <= ?', Date.today - 7, Date.today])
-      li.next
-        - shared_info = SharedInfo.this_period.order(:id).first
-        = link_to(shared_info_path(shared_info.id)) do
-          = shared_info.title
-          span aria-hidden="true"
-            | &nbsp;&rarr;
+  - if Team.has_next_team?(@team.order)
+    li.next
+      - next_team = Team.next_team(@team.order)
+      = link_to(team_path(next_team.id)) do
+        = next_team.name
+        span aria-hidden="true"
+          | &nbsp;&rarr;
+  - elsif SharedInfo.exists?(['? < announce_date AND announce_date <= ?', Date.today - 7, Date.today])
+    li.next
+      - shared_info = SharedInfo.this_period.order(:id).first
+      = link_to(shared_info_path(shared_info.id)) do
+        = shared_info.title
+        span aria-hidden="true"
+          | &nbsp;&rarr;

--- a/app/views/teams/show.html.slim
+++ b/app/views/teams/show.html.slim
@@ -6,9 +6,8 @@
       = "今月の達成度 : #{number_to_currency(@sum, :unit => "", :precision => 0)} / #{number_to_currency(@goal.goal, :unit => "", :precision => 0)} #{@entity} (#{((@sum.to_f/@goal.goal.to_f) * 100).to_i}%)"
 
 .container-preview
-  = render partial: 'next_prev_button'
-
   hr
+  = render partial: 'next_prev_button'
   .row
     .col-xs-6
       - if @team.goals.present?

--- a/app/views/teams/show.html.slim
+++ b/app/views/teams/show.html.slim
@@ -6,6 +6,31 @@
       = "今月の達成度 : #{number_to_currency(@sum, :unit => "", :precision => 0)} / #{number_to_currency(@goal.goal, :unit => "", :precision => 0)} #{@entity} (#{((@sum.to_f/@goal.goal.to_f) * 100).to_i}%)"
 
 .container-preview
+  ul.pager
+    - if Team.has_prev_team?(@team.order)
+      li.previous
+        - prev_team = Team.prev_team(@team.order)
+        = link_to(team_path(prev_team.id)) do
+          span aria-hidden="true"
+            | &larr;&nbsp;
+          = prev_team.name
+
+    - if Team.has_next_team?(@team.order)
+      li.next
+        - next_team = Team.next_team(@team.order)
+        = link_to(team_path(next_team.id)) do
+          = next_team.name
+          span aria-hidden="true"
+            | &nbsp;&rarr;
+    - elsif SharedInfo.exists?(['? < announce_date AND announce_date <= ?', Date.today - 7, Date.today])
+      li.next
+        - shared_info = SharedInfo.this_period.order(:id).first
+        = link_to(shared_info_path(shared_info.id)) do
+          = shared_info.title
+          span aria-hidden="true"
+            | &nbsp;&rarr;
+
+.container-preview
   hr
 
 .container-preview

--- a/app/views/teams/show.html.slim
+++ b/app/views/teams/show.html.slim
@@ -5,12 +5,10 @@
     h3
       = "今月の達成度 : #{number_to_currency(@sum, :unit => "", :precision => 0)} / #{number_to_currency(@goal.goal, :unit => "", :precision => 0)} #{@entity} (#{((@sum.to_f/@goal.goal.to_f) * 100).to_i}%)"
 
-= render partial: 'next_prev_button'
-
 .container-preview
+  = render partial: 'next_prev_button'
+
   hr
-
-.container-preview
   .row
     .col-xs-6
       - if @team.goals.present?
@@ -19,8 +17,6 @@
       - if @topic.present?
         .container-topics
           = markdown(@topic.content)
-
-.container-preview
   hr
 
-= render partial: 'next_prev_button'
+  = render partial: 'next_prev_button'

--- a/app/views/teams/show.html.slim
+++ b/app/views/teams/show.html.slim
@@ -5,30 +5,7 @@
     h3
       = "今月の達成度 : #{number_to_currency(@sum, :unit => "", :precision => 0)} / #{number_to_currency(@goal.goal, :unit => "", :precision => 0)} #{@entity} (#{((@sum.to_f/@goal.goal.to_f) * 100).to_i}%)"
 
-.container-preview
-  ul.pager
-    - if Team.has_prev_team?(@team.order)
-      li.previous
-        - prev_team = Team.prev_team(@team.order)
-        = link_to(team_path(prev_team.id)) do
-          span aria-hidden="true"
-            | &larr;&nbsp;
-          = prev_team.name
-
-    - if Team.has_next_team?(@team.order)
-      li.next
-        - next_team = Team.next_team(@team.order)
-        = link_to(team_path(next_team.id)) do
-          = next_team.name
-          span aria-hidden="true"
-            | &nbsp;&rarr;
-    - elsif SharedInfo.exists?(['? < announce_date AND announce_date <= ?', Date.today - 7, Date.today])
-      li.next
-        - shared_info = SharedInfo.this_period.order(:id).first
-        = link_to(shared_info_path(shared_info.id)) do
-          = shared_info.title
-          span aria-hidden="true"
-            | &nbsp;&rarr;
+= render partial: 'next_prev_button'
 
 .container-preview
   hr
@@ -46,27 +23,4 @@
 .container-preview
   hr
 
-.container-preview
-  ul.pager
-    - if Team.has_prev_team?(@team.order)
-      li.previous
-        - prev_team = Team.prev_team(@team.order)
-        = link_to(team_path(prev_team.id)) do
-          span aria-hidden="true"
-            | &larr;&nbsp;
-          = prev_team.name
-
-    - if Team.has_next_team?(@team.order)
-      li.next
-        - next_team = Team.next_team(@team.order)
-        = link_to(team_path(next_team.id)) do
-          = next_team.name
-          span aria-hidden="true"
-            | &nbsp;&rarr;
-    - elsif SharedInfo.exists?(['? < announce_date AND announce_date <= ?', Date.today - 7, Date.today])
-      li.next
-        - shared_info = SharedInfo.this_period.order(:id).first
-        = link_to(shared_info_path(shared_info.id)) do
-          = shared_info.title
-          span aria-hidden="true"
-            | &nbsp;&rarr;
+= render partial: 'next_prev_button'


### PR DESCRIPTION
see also: #99

毎回全体朝会を見ていて、ちょっとだけスクロールしているのが気になったので、最初からヘッダを表示しないようにしてみました。
ヘッダ部分はトップページへの遷移のみにしか使われていないように見えたので。
もし、不要ということであれば close してもらって構わないです。

## 変更したところ
* teams/show に遷移したら、ヘッダが隠れるくらいまでスクロールするようにしました

## やってないこと
* スムーズスクロールにはしてないので、ページ遷移したらヘッダが消えてる感があるかもしれません
  * かといって、毎度ページを表示するごとに動くのもちょっと変かなと思ったので

## 相談したいこと
* もしかしたら、 teams/show に遷移したらヘッダを表示しない。という方法もあったかもしれません
* js のコードがそんなに長くないので、 teams/show.html.slim に直書きしてしまいました
* 短くてもいいから、ファイルは分けて欲しい…とかあれば分けます

## 見て欲しいところ
* 各チームのトピックにスクロールしなければいけないくらいのトピックを入力した後、遷移するか
  * トピック量が多くなければ、スクロールしない
* リロードしてもタブが隠れるくらいスクロールされるか
* スクロール位置も大丈夫そうか