### PR TITLE
team/show を表示する際、チーム名から表示させるようにした PR の作り直し

### DIFF
--- a/app/views/teams/show.html.slim
+++ b/app/views/teams/show.html.slim
@@ -1,3 +1,8 @@
+javascript:
+  (window.onload = function() {
+    window.scrollTo( 0, 70 );
+  })();
+
 .container
   h1
     = "#{@team.name} チーム"


### PR DESCRIPTION
see also: #99

毎回全体朝会を見ていて、ちょっとだけスクロールしているのが気になったので、最初からヘッダを表示しないようにしてみました。
ヘッダ部分はトップページへの遷移のみにしか使われていないように見えたので。
もし、不要ということであれば close してもらって構わないです。
## 変更したところ
- teams/show に遷移したら、ヘッダが隠れるくらいまでスクロールするようにしました
## やってないこと
- スムーズスクロールにはしてないので、ページ遷移したらヘッダが消えてる感があるかもしれません
  - かといって、毎度ページを表示するごとに動くのもちょっと変かなと思ったので
## 相談したいこと
- もしかしたら、 teams/show に遷移したらヘッダを表示しない。という方法もあったかもしれません
- js のコードがそんなに長くないので、 teams/show.html.slim に直書きしてしまいました
- 短くてもいいから、ファイルは分けて欲しい…とかあれば分けます
## 見て欲しいところ
- 各チームのトピックにスクロールしなければいけないくらいのトピックを入力した後、遷移するか
  - トピック量が多くなければ、スクロールしない
- リロードしてもタブが隠れるくらいスクロールされるか
- スクロール位置も大丈夫そうか
