### PR TITLE
営業日を判定するモジュールを追加する

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,6 +53,8 @@ gem 'bootstrap3-datetimepicker-rails'
 gem 'rack-ip_address_restriction'
 gem 'dotenv-rails'
 
+gem 'holiday_jp'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platform: :mri

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,6 +86,7 @@ GEM
     hirb-unicode (0.0.5)
       hirb (~> 0.5)
       unicode-display_width (~> 0.1.1)
+    holiday_jp (0.5.0)
     i18n (0.7.0)
     jbuilder (2.6.0)
       activesupport (>= 3.0.0, < 5.1)
@@ -265,6 +266,7 @@ DEPENDENCIES
   factory_girl_rails
   hirb
   hirb-unicode
+  holiday_jp
   jbuilder (~> 2.5)
   jquery-rails
   lazy_high_charts

--- a/app/models/holiday_calendar.rb
+++ b/app/models/holiday_calendar.rb
@@ -18,4 +18,8 @@ module HolidayCalendar
   def self.next_start_week_day(date)
     start_week_day(date + 7)
   end
+
+  def self.next_end_week_day(date)
+    end_week_day(date + 7)
+  end
 end

--- a/app/models/holiday_calendar.rb
+++ b/app/models/holiday_calendar.rb
@@ -6,4 +6,12 @@ module HolidayCalendar
       start_date += 1.days
     end
   end
+
+  def self.end_week_day(date)
+    end_date = date - (date.wday - 5)
+    loop do
+      return end_date unless HolidayJp.holiday?(end_date)
+      end_date -= 1.days
+    end
+  end
 end

--- a/app/models/holiday_calendar.rb
+++ b/app/models/holiday_calendar.rb
@@ -14,4 +14,8 @@ module HolidayCalendar
       end_date -= 1.days
     end
   end
+
+  def self.next_start_week_day(date)
+    start_week_day(date + 7)
+  end
 end

--- a/app/models/holiday_calendar.rb
+++ b/app/models/holiday_calendar.rb
@@ -26,4 +26,8 @@ module HolidayCalendar
   def self.last_start_week_day(date)
     start_week_day(date - 7)
   end
+
+  def self.last_end_week_day(date)
+    end_week_day(date - 7)
+  end
 end

--- a/app/models/holiday_calendar.rb
+++ b/app/models/holiday_calendar.rb
@@ -1,0 +1,9 @@
+module HolidayCalendar
+  def self.start_week_day(date)
+    start_date = date - (date.wday - 1)
+    loop do
+      return start_date unless HolidayJp.holiday?(start_date)
+      start_date += 1.days
+    end
+  end
+end

--- a/app/models/holiday_calendar.rb
+++ b/app/models/holiday_calendar.rb
@@ -22,4 +22,8 @@ module HolidayCalendar
   def self.next_end_week_day(date)
     end_week_day(date + 7)
   end
+
+  def self.last_start_week_day(date)
+    start_week_day(date - 7)
+  end
 end

--- a/spec/models/holiday_calendar_spec.rb
+++ b/spec/models/holiday_calendar_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+RSpec.describe HolidayCalendar, type: :lib do
+  describe '.start_week_day' do
+    subject { HolidayCalendar.start_week_day(date) }
+
+    context '月曜日が祝日ではない場合' do
+      # NOTE: 2016年10月24日(月) は平日
+      let(:date) { Date.new(2016, 10, 26) }
+
+      it '月曜日の日付が返る' do
+        expect(subject).to eq Date.new(2016, 10, 24)
+      end
+    end
+
+    context '月曜日が祝日の場合' do
+      # NOTE: 2016年10月10日(月) は祝日
+      let(:date) { Date.new(2016, 10, 12) }
+
+      it '火曜日の日付が返る' do
+        expect(subject).to eq Date.new(2016, 10, 11)
+      end
+    end
+
+    context '月曜日から祝日が続いている場合' do
+      # NOTE: 2015年05月04日(月) ~ 2015年05月06日(水) は祝日
+      let(:date) { Date.new(2015, 5, 6) }
+
+      it '１番最初の平日を返す' do
+        expect(subject).to eq Date.new(2015, 5, 7)
+      end
+    end
+  end
+end

--- a/spec/models/holiday_calendar_spec.rb
+++ b/spec/models/holiday_calendar_spec.rb
@@ -31,4 +31,35 @@ RSpec.describe HolidayCalendar, type: :lib do
       end
     end
   end
+
+  describe '.end_week_day' do
+    subject { HolidayCalendar.end_week_day(date) }
+
+    context '金曜日が祝日ではない場合' do
+      # NOTE: 2016年10月28日(金) は平日
+      let(:date) { Date.new(2016, 10, 26) }
+
+      it '金曜日の日付が返る' do
+        expect(subject).to eq Date.new(2016, 10, 28)
+      end
+    end
+
+    context '金曜日が祝日の場合' do
+      # NOTE: 2016年12月23日(金) は祝日
+      let(:date) { Date.new(2016, 12, 21) }
+
+      it '木曜日の日付が返る' do
+        expect(subject).to eq Date.new(2016, 12, 22)
+      end
+    end
+
+    context '金曜日から祝日が続いている場合' do
+      # NOTE: 2017年05月03日(水) ~ 2017年05月05日(金) は祝日
+      let(:date) { Date.new(2017, 5, 4) }
+
+      it '１番最初の平日を返す' do
+        expect(subject).to eq Date.new(2017, 5, 2)
+      end
+    end
+  end
 end

--- a/spec/models/holiday_calendar_spec.rb
+++ b/spec/models/holiday_calendar_spec.rb
@@ -155,4 +155,35 @@ RSpec.describe HolidayCalendar, type: :lib do
       end
     end
   end
+
+  describe '.last_end_week_day' do
+    subject { HolidayCalendar.last_end_week_day(date) }
+
+    context '金曜日が祝日ではない場合' do
+      # NOTE: 2016年10月28日(金) は平日
+      let(:date) { Date.new(2016, 11, 2) }
+
+      it '先週の金曜日の日付が返る' do
+        expect(subject).to eq Date.new(2016, 10, 28)
+      end
+    end
+
+    context '金曜日が祝日の場合' do
+      # NOTE: 2016年12月23日(金) は祝日
+      let(:date) { Date.new(2016, 12, 28) }
+
+      it '先週の木曜日の日付が返る' do
+        expect(subject).to eq Date.new(2016, 12, 22)
+      end
+    end
+
+    context '金曜日から祝日が続いている場合' do
+      # NOTE: 2017年05月03日(水) ~ 2017年05月05日(金) は祝日
+      let(:date) { Date.new(2017, 5, 11) }
+
+      it '先週の１番最初の平日を返す' do
+        expect(subject).to eq Date.new(2017, 5, 2)
+      end
+    end
+  end
 end

--- a/spec/models/holiday_calendar_spec.rb
+++ b/spec/models/holiday_calendar_spec.rb
@@ -124,4 +124,35 @@ RSpec.describe HolidayCalendar, type: :lib do
       end
     end
   end
+
+  describe '.last_start_week_day' do
+    subject { HolidayCalendar.last_start_week_day(date) }
+
+    context '月曜日が祝日ではない場合' do
+      # NOTE: 2016年10月24日(月) は平日
+      let(:date) { Date.new(2016, 11, 2) }
+
+      it '先週の月曜日の日付が返る' do
+        expect(subject).to eq Date.new(2016, 10, 24)
+      end
+    end
+
+    context '月曜日が祝日の場合' do
+      # NOTE: 2016年10月10日(月) は祝日
+      let(:date) { Date.new(2016, 10, 19) }
+
+      it '先週の火曜日の日付が返る' do
+        expect(subject).to eq Date.new(2016, 10, 11)
+      end
+    end
+
+    context '月曜日から祝日が続いている場合' do
+      # NOTE: 2015年05月04日(月) ~ 2015年05月06日(水) は祝日
+      let(:date) { Date.new(2015, 5, 13) }
+
+      it '先週の１番最初の平日を返す' do
+        expect(subject).to eq Date.new(2015, 5, 7)
+      end
+    end
+  end
 end

--- a/spec/models/holiday_calendar_spec.rb
+++ b/spec/models/holiday_calendar_spec.rb
@@ -93,4 +93,35 @@ RSpec.describe HolidayCalendar, type: :lib do
       end
     end
   end
+
+  describe '.end_week_day' do
+    subject { HolidayCalendar.next_end_week_day(date) }
+
+    context '金曜日が祝日ではない場合' do
+      # NOTE: 2016年10月28日(金) は平日
+      let(:date) { Date.new(2016, 10, 19) }
+
+      it '来週の金曜日の日付が返る' do
+        expect(subject).to eq Date.new(2016, 10, 28)
+      end
+    end
+
+    context '金曜日が祝日の場合' do
+      # NOTE: 2016年12月23日(金) は祝日
+      let(:date) { Date.new(2016, 12, 14) }
+
+      it '来週の木曜日の日付が返る' do
+        expect(subject).to eq Date.new(2016, 12, 22)
+      end
+    end
+
+    context '金曜日から祝日が続いている場合' do
+      # NOTE: 2017年05月03日(水) ~ 2017年05月05日(金) は祝日
+      let(:date) { Date.new(2017, 4, 27) }
+
+      it '来週の１番最初の平日を返す' do
+        expect(subject).to eq Date.new(2017, 5, 2)
+      end
+    end
+  end
 end

--- a/spec/models/holiday_calendar_spec.rb
+++ b/spec/models/holiday_calendar_spec.rb
@@ -62,4 +62,35 @@ RSpec.describe HolidayCalendar, type: :lib do
       end
     end
   end
+
+  describe '.next_start_week_day' do
+    subject { HolidayCalendar.next_start_week_day(date) }
+
+    context '月曜日が祝日ではない場合' do
+      # NOTE: 2016年10月24日(月) は平日
+      let(:date) { Date.new(2016, 10, 19) }
+
+      it '来週の月曜日の日付が返る' do
+        expect(subject).to eq Date.new(2016, 10, 24)
+      end
+    end
+
+    context '月曜日が祝日の場合' do
+      # NOTE: 2016年10月10日(月) は祝日
+      let(:date) { Date.new(2016, 10, 5) }
+
+      it '来週の火曜日の日付が返る' do
+        expect(subject).to eq Date.new(2016, 10, 11)
+      end
+    end
+
+    context '月曜日から祝日が続いている場合' do
+      # NOTE: 2015年05月04日(月) ~ 2015年05月06日(水) は祝日
+      let(:date) { Date.new(2015, 4, 30) }
+
+      it '来週の１番最初の平日を返す' do
+        expect(subject).to eq Date.new(2015, 5, 7)
+      end
+    end
+  end
 end


### PR DESCRIPTION
issue #101 

やること
---
+ 祝日判定込みのカレンダー(gem) の導入
    + [holiday-jp/holiday_jp-ruby: Japanese holiday.](https://github.com/holiday-jp/holiday_jp-ruby) を採用
+ 営業日判定を行う HolidayCalendar モジュールを追加した
   + 日付を与えると、その日付が属する週の開始日と終了日を返す
   + 先週分と来週分の開始日、終了日を返すメソッドも一応用意した
+ 日付は日曜始まりとなっている


やってないこと
---
+ 該当箇所の日付アルゴリズムの変更
+ カスタムな日付の祝日判定追加した
